### PR TITLE
Remove /index on redirect back to home

### DIFF
--- a/google-codelab.html
+++ b/google-codelab.html
@@ -429,10 +429,13 @@ Example:
             break;
           }
         }
-        if (!index) {
-          index = '/';
+
+        var returnToIndex = index ? decodeURIComponent(index) : index;
+        if (!returnToIndex || returnToIndex.slice(-6) === '/index') {
+          returnToIndex = '/';
         }
-        window.location.href = decodeURIComponent(index);
+
+        window.location.href = returnToIndex;
       },
 
       _tocItemClass: function(selected, i) {


### PR DESCRIPTION
R: @marcacohen @crhym3 

If you click a codelab from the homepage and then hit the back button, it takes you to `http://www.code-labs.io/index`. This update takes you to `http://www.code-labs.io/`.