### PR TITLE
step-style: add <a><paper-button> styling

### DIFF
--- a/demo/codelab.html
+++ b/demo/codelab.html
@@ -72,6 +72,11 @@ the License.
 
 <aside class="special"><p>This codelab uses Chrome Dev Editor, a Chrome app IDE. If you don't have it installed yet, please install it from Chrome Web Store.</p>
 <p><paper-button raised class="colored"><iron-icon icon="file-download"></iron-icon><a href="https://chrome.google.com/webstore/detail/chrome-dev-editor-develop/pnoffddplpippgcfjdhbmhkofpnaalpg?hl=en">Download Chrome Dev Editor</a></paper-button></p></aside>
+
+<p>A paper-button wrapped into anchor element:</p>
+<p><a href="https://example.org"><paper-button raised class="colored"><iron-icon icon="file-download"></iron-icon>Example with an icon</paper-button></a></p>
+<p><a href="https://example.org"><paper-button raised class="colored">Example without an icon</paper-button></a></p>
+
 <p>The first time you run Chrome Dev Editor it will ask you to setup your workspace environment.</p><p>Fire up Chrome Dev Editor and start a new project:</p><ol start="1">
 <li>Click <img src="img-2.png" style="max-width: 27px">to start a new project.</li>
 <li>Enter <strong>"PolymerMapsCodelab"</strong>&#160;as the <strong>Project name</strong>.</li>

--- a/step-style.html
+++ b/step-style.html
@@ -194,6 +194,13 @@ the License.
         color: inherit !important;
       }
 
+      .instructions ::content a paper-button {
+        /* The text-decoration styling doesn't apply to inline blocks.
+           We use this trick to remove underline when paper-button
+           is wrapped in the anchor element. */
+        display: inline-block;
+      }
+
       .instructions ::content paper-button.colored {
         background-color: var(--google-material-green-600);
       }


### PR DESCRIPTION
All this time we've had the following "download" paper-button structure
on the official website at https://g.co/codelabs:

    <a href="..."><paper-button>download</paper-button></a>

Note that this is in accordance with the Polymer 1.0 recommendation
in https://elements.polymer-project.org/bower_components/paper-button/demo/index.html

Unfortunately, this is not how codelab-components were styled all this
time. A demo codelab has the inverse structure:

    <paper-button><a href="...">download</a></paper-button>

Here's where it's used in codelab-components repo:

https://github.com/googlecodelabs/codelab-components/blob/7397f708d210dfbb7348084033a32ba070ec4df4/demo/codelab.html#L74

As a consequence, the styling Will provided in a recent change in https://github.com/googlecodelabs/codelab-components/commit/f3e63d5612e67e9e35804f0992807c4aec5cbd8e used the latter structure. We never noticed the difference because before the styling refresh, the download button background and link
colors were very close.

All this change really does is it removes the text underline. The rest of the styling already matches. 